### PR TITLE
BugFix: Race condition in authorizationToken

### DIFF
--- a/Source/VLBeaconLib/BeaconEvent/UserBeaconModel/UserBeaconEventStruct.swift
+++ b/Source/VLBeaconLib/BeaconEvent/UserBeaconModel/UserBeaconEventStruct.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public struct UserBeaconEventStruct {
-    
     var ename: String
     var uid: String!
     var profid: String!
@@ -26,8 +25,20 @@ public struct UserBeaconEventStruct {
     var anonymousuid: String?
     var eventType: String?
     
-    public init(eventName: UserBeaconEventEnum, userId: String? = nil, profileId: String? = nil, siteId: String? = nil, pfm: String? = nil, etstamp: String? = nil, environment: String? = nil, appversion: String? = nil, source: String?, eventData: BeaconEventPayloadProtocol? = nil, additionalData: [String : Any]? = nil, tokenIdentity: TokenIdentity?) {
-        
+    public init(
+        eventName: UserBeaconEventEnum,
+        userId: String? = nil,
+        profileId: String? = nil,
+        siteId: String? = nil,
+        pfm: String? = nil,
+        etstamp: String? = nil,
+        environment: String? = nil,
+        appversion: String? = nil,
+        source: String?,
+        eventData: BeaconEventPayloadProtocol? = nil,
+        additionalData: [String : Any]? = nil,
+        tokenIdentity: TokenIdentity?
+    ) {
         let tokenId = tokenIdentity ?? VLBeacon.getInstance().tokenIdentity
         
         self.ename = eventName.getBeaconEventNameString()
@@ -51,7 +62,7 @@ public struct UserBeaconEventStruct {
             self.siteid = siteId
         }
         
-        if let source{
+        if let source {
             self.source = source
         } else {
             self.source = "VLBeacon"
@@ -66,21 +77,12 @@ public struct UserBeaconEventStruct {
         self.eventdata = eventData?.toDictionary()
         
         self.additionaldata = additionalData
-        
     }
 }
 
-extension UserBeaconEventStruct: BeaconEventBodyProtocol {
-    
-    public func triggerEvents(authToken: String, beaconInstance: VLBeacon) {
-        guard let beaconBaseURL = beaconInstance.userBeaconUrl else { return }
-        
-        DispatchQueue.global(qos: .utility).async {
-            DataManger().postBeaconEvents(beaconStructBody: self, authenticationToken: authToken, baseUrl: beaconBaseURL)
-        }
-    }
-    
-    public func addBeaconInDBQuery() -> String? {
+// MARK: - Public methods
+public extension UserBeaconEventStruct {
+    func addBeaconInDBQuery() -> String? {
         var queryToAddBeaconEvent: String?
         
         let additionalDataString: String? = additionaldata?.jsonString()
@@ -90,5 +92,16 @@ extension UserBeaconEventStruct: BeaconEventBodyProtocol {
         queryToAddBeaconEvent = "insert into \(BeaconDBConstants().USERTABLENAME) (ename, uid, profid, siteid, pfm, etstamp, environment, deviceid, ref, url, appversion, source, eventData, additionalData) values('\(self.ename )','\(self.uid ?? "")','\(profid ?? "")','\(self.siteid ?? "")','\(self.pfm ?? "")','\(self.etstamp ?? "")','\(self.environment ?? "")','\(self.deviceid ?? "")','\(self.ref ?? "")','\(self.url ?? "")','\(self.appversion ?? "")','\(self.source ?? "")','\(eventDataString ?? "")','\(additionalDataString ?? "")')"
         
         return queryToAddBeaconEvent
+    }
+}
+
+// MARK: - BeaconEventBodyProtocol implementation
+extension UserBeaconEventStruct: BeaconEventBodyProtocol {
+    public func triggerEvents(authToken: String, beaconInstance: VLBeacon) {
+        guard let beaconBaseURL = beaconInstance.userBeaconUrl else { return }
+        
+        DispatchQueue.global(qos: .utility).async {
+            DataManger().postBeaconEvents(beaconStructBody: self, authenticationToken: authToken, baseUrl: beaconBaseURL)
+        }
     }
 }

--- a/Source/VLBeaconLib/DBManager/BeaconDBManager.swift
+++ b/Source/VLBeaconLib/DBManager/BeaconDBManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 @_implementationOnly import SQLite3
 
-class BeaconDBManager {
+final class BeaconDBManager {
     /*!
      * @brief Path the documents directory.
      */
@@ -25,8 +25,11 @@ class BeaconDBManager {
     var arrColumnNames = [Any]()
     var affectedRows : Int = 01
     var lastInsertedRowID : Double  = 01
-    
-    func intializeData( dbFilename: String, tableName: String,  tableColumnsQuery: String)  {
+}
+
+// MARK: - Internal methods
+extension BeaconDBManager {
+    func intializeData( dbFilename: String, tableName: String, tableColumnsQuery: String)  {
         // Set the documents directory path to the documentsDirectory property.
         let paths: [String] = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         documentsDirectory = paths[0]
@@ -41,32 +44,49 @@ class BeaconDBManager {
         let _database: String = URL(fileURLWithPath: documentsDirectory).appendingPathComponent(dbFileName).absoluteString
         let fileMngr = FileManager.default
         //Check if file already exists. If yes, do not create new.
-        if fileMngr.fileExists(atPath: _database) == false {
-            // Create a sqlite object.
-            var _DB: OpaquePointer?
-//            let dbpath = _database.utf8
-            if sqlite3_open(_database, &_DB) == SQLITE_OK {
-                var errorMassage:String = ""
-                if let error = sqlite3_errmsg(_DB){
-                    errorMassage = String(cString: error)
-                }
-                let sql_statement = "CREATE TABLE IF NOT EXISTS \(tableName) (\(tableColumnsQuery))"
-                if sqlite3_exec(_DB, sql_statement, nil, nil, nil) != SQLITE_OK {
-                    #if DEBUG
-                    debugPrint("error creating table: \(errorMassage)")
-                    #endif
-                }
-                sqlite3_close(_DB)
+        guard fileMngr.fileExists(atPath: _database) == false else { return }
+        // Create a sqlite object.
+        var _DB: OpaquePointer?
+        //            let dbpath = _database.utf8
+        if sqlite3_open(_database, &_DB) == SQLITE_OK {
+            var errorMassage:String = ""
+            
+            if let error = sqlite3_errmsg(_DB){
+                errorMassage = String(cString: error)
             }
-            else {
-                #if DEBUG
-                debugPrint("Error to open/create the table")
-                #endif
+            
+            let sql_statement = "CREATE TABLE IF NOT EXISTS \(tableName) (\(tableColumnsQuery))"
+            
+            if sqlite3_exec(_DB, sql_statement, nil, nil, nil) != SQLITE_OK {
+#if DEBUG
+                debugPrint("error creating table: \(errorMassage)")
+#endif
             }
+            sqlite3_close(_DB)
+        } else {
+#if DEBUG
+            debugPrint("Error to open/create the table")
+#endif
         }
     }
     
-   private func runQuery(_ query: String, isQueryExecutable queryExecutable: Bool) {
+    func loadData(fromDB query: String) -> Array<Dictionary<String,String>> {
+        // Run the query and indicate that is not executable.
+        // The query string is converted to a char* object.
+        runQuery(query, isQueryExecutable: false)
+        // Returned the loaded results.
+        return (results)
+    }
+    
+    func execute(_ query: String) {
+        // Run the query and indicate that is executable.
+        runQuery(query, isQueryExecutable: true)
+    }
+}
+
+// MARK: - Private methods
+private extension BeaconDBManager {
+    func runQuery(_ query: String, isQueryExecutable queryExecutable: Bool) {
         // Create a sqlite object.
         var sqlite3Database: OpaquePointer?
         // Set the database file path.
@@ -76,12 +96,14 @@ class BeaconDBManager {
             results.removeAll()
             // arrResults = nil
         }
+        
         arrResults = [Any]()
         // Initialize the column names array.
         if !arrColumnNames.isEmpty {
             arrColumnNames.removeAll()
             //arrColumnNames = nil
         }
+        
         //var result:Array<Dictionary<String,AnyObject>>=[]
         arrColumnNames = [Any]()
         // Open the database.
@@ -115,13 +137,12 @@ class BeaconDBManager {
                             dict[rFiled] = rValue as String?
                             // result.insert(mod, at: result.count)
                         }
+                        
                         results.insert(dict , at: results.count)
                         
                     }
                     // Store each fetched data row in the results array, but first check if there is actually data.
-                }
-                    
-                else {
+                } else {
                     // This is the case of an executable query (insert, update, ...).
                     // Execute the query.
                     if SQLITE_DONE == sqlite3_step(compiledStatement) {
@@ -129,32 +150,18 @@ class BeaconDBManager {
                         affectedRows = Int(sqlite3_changes(sqlite3Database))
                         // Keep the last inserted row ID.
                         //lastInsertedRowID = Double(sqlite3_last_insert_rowid(sqlite3Database))
-                    }
-                    else {
+                    } else {
                         // If could not execute the query show the error message on the debugger.
-                        #if DEBUG
+#if DEBUG
                         debugPrint("DB Error: \(String(describing: sqlite3_errmsg(sqlite3Database))) \(query)")
-                        #endif
+#endif
                     }
                 }
-                
             }
+            
             sqlite3_finalize(compiledStatement)
         }
         
         sqlite3_close(sqlite3Database)
-    }
-    
-    func loadData(fromDB query: String) -> Array<Dictionary<String,String>> {
-        // Run the query and indicate that is not executable.
-        // The query string is converted to a char* object.
-        runQuery(query, isQueryExecutable: false)
-        // Returned the loaded results.
-        return (results)
-    }
-    
-    func execute(_ query: String) {
-        // Run the query and indicate that is executable.
-        runQuery(query, isQueryExecutable: true)
     }
 }

--- a/Source/VLBeaconLib/DBManager/BeaconOfflineHandle.swift
+++ b/Source/VLBeaconLib/DBManager/BeaconOfflineHandle.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  BeaconOfflineHandle.swift
+//
 //
 //  Created by Ratnakar Gautam on 15/01/25.
 //
@@ -8,13 +8,13 @@
 import Foundation
 import UIKit
 
-class BeaconOfflineHandle {
+final class BeaconOfflineHandle {
     private static let fileAccessQueue = DispatchQueue(label: "com.beaconOfflineHandle.fileAccessQueue")
-    
-    private static var beaconFilePath: URL? {
-        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("beacon_events.plist")
-    }
+    private static let beaconFilePath: URL? = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("beacon_events.plist")
+}
 
+// MARK: - Internal methods
+extension BeaconOfflineHandle {
     static func saveDataToLocal(newDict: [String: Any]) {
         fileAccessQueue.sync {
             do {
@@ -27,9 +27,9 @@ class BeaconOfflineHandle {
             }
         }
     }
-
+    
     static func fetchLocalData() -> [[String: Any]]? {
-        return fileAccessQueue.sync {
+        fileAccessQueue.sync {
             do {
                 return try readPlistData()
             } catch {
@@ -38,7 +38,7 @@ class BeaconOfflineHandle {
             }
         }
     }
-
+    
     static func deleteDictionaryAt(index: Int) {
         fileAccessQueue.sync {
             do {
@@ -52,32 +52,33 @@ class BeaconOfflineHandle {
             }
         }
     }
-
+    
     static func triggerSavedEvents() {
         fileAccessQueue.sync {
             guard let authToken = VLBeacon.getInstance().authorizationToken else { return }
             let beaconInstance = VLBeacon.getInstance()
-
+            
             do {
                 var savedEvents = try readPlistData()
                 var successfullyTriggeredIndices: [Int] = []
-
+                
                 // Aggregate events by type
                 var userEvents: [[String: Any]] = []
                 var playerEvents: [[String: Any]] = []
-
+                
                 for (index, tempDict) in savedEvents.enumerated() {
                     var eventDict = tempDict
+                    
                     guard let eventTypeString = eventDict["eventType"] as? String,
                           let eventType = BeaconType(rawValue: eventTypeString.capitalized) else {
                         continue
                     }
-
+                    
                     eventDict.removeValue(forKey: "eventType")
-
+                    
                     // Process event dictionary
                     processEventDict(&eventDict, beaconInstance: beaconInstance)
-
+                    
                     // Append to appropriate event type array
                     switch eventType {
                     case .user:
@@ -85,32 +86,36 @@ class BeaconOfflineHandle {
                     case .player:
                         playerEvents.append(eventDict)
                     }
-
+                    
                     // Mark the index for successful processing
                     successfullyTriggeredIndices.append(index)
                 }
-
+                
                 // Trigger events for each type
                 triggerEvents(userEvents, beaconInstance: beaconInstance, authToken: authToken, beaconType: .user)
                 triggerEvents(playerEvents, beaconInstance: beaconInstance, authToken: authToken, beaconType: .player)
-
+                
                 // Remove successfully triggered events from saved data
                 removeProcessedEvents(&savedEvents, successfullyTriggeredIndices)
                 try writePlistData(savedEvents)
             } catch {
-                print("Error triggering saved events: $error)")
+                print("Error triggering saved events: \(error)")
             }
         }
     }
+}
 
+// MARK: - Private methods
+private extension BeaconOfflineHandle {
     // Helper function to process event dictionary
-    private static func processEventDict(_ eventDict: inout [String: Any], beaconInstance: VLBeacon) {
+    static func processEventDict(_ eventDict: inout [String: Any], beaconInstance: VLBeacon) {
         guard let uID = beaconInstance.tokenIdentity?.userId as? String else { return }
+        
         let anonymousId = beaconInstance.tokenIdentity?.anonymousId as? String
         
         eventDict["aid"] = beaconInstance.tokenIdentity?.siteName ?? ""
         eventDict["cid"] = beaconInstance.tokenIdentity?.siteId ?? ""
-
+        
         if let anonymousId = anonymousId, !anonymousId.isEmpty {
             if eventDict["profid"] == nil || (eventDict["profid"] as? String ?? "").isEmpty {
                 eventDict["profid"] = "guest-user"
@@ -127,29 +132,29 @@ class BeaconOfflineHandle {
             }
         }
     }
-
+    
     // Helper function to trigger events
-    private static func triggerEvents(_ events: [[String: Any]], beaconInstance: VLBeacon, authToken: String, beaconType: BeaconType) {
-        if !events.isEmpty {
-            BeaconSyncManager.sharedInstance.postDataToServer(
-                vlBeacon: beaconInstance,
-                arrayOfBeaconEvents: events,
-                authenticationToken: authToken,
-                beaconType: beaconType
-            )
-        }
+    static func triggerEvents(_ events: [[String: Any]], beaconInstance: VLBeacon, authToken: String, beaconType: BeaconType) {
+        guard !events.isEmpty else { return }
+        
+        BeaconSyncManager.sharedInstance.postDataToServer(
+            vlBeacon: beaconInstance,
+            arrayOfBeaconEvents: events,
+            authenticationToken: authToken,
+            beaconType: beaconType
+        )
     }
-
+    
     // Helper function to remove processed events
-    private static func removeProcessedEvents(_ savedEvents: inout [[String: Any]], _ successfullyTriggeredIndices: [Int]) {
-        if !successfullyTriggeredIndices.isEmpty {
-            for index in successfullyTriggeredIndices.sorted(by: >) {
-                savedEvents.remove(at: index)
-            }
+    static func removeProcessedEvents(_ savedEvents: inout [[String: Any]], _ successfullyTriggeredIndices: [Int]) {
+        guard !successfullyTriggeredIndices.isEmpty else { return }
+        
+        for index in successfullyTriggeredIndices.sorted(by: >) {
+            savedEvents.remove(at: index)
         }
     }
-
-    private static func readPlistData() throws -> [[String: Any]] {
+    
+    static func readPlistData() throws -> [[String: Any]] {
         guard let filePath = beaconFilePath else { return [] }
         
         // Check if the file exists
@@ -161,8 +166,8 @@ class BeaconOfflineHandle {
         let data = try Data(contentsOf: filePath)
         return try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [[String: Any]] ?? []
     }
-
-    private static func writePlistData(_ data: [[String: Any]]) throws {
+    
+    static func writePlistData(_ data: [[String: Any]]) throws {
         guard let filePath = beaconFilePath else { return }
         
         // Serialize the data and write to the file
@@ -170,4 +175,3 @@ class BeaconOfflineHandle {
         try plistData.write(to: filePath)
     }
 }
-

--- a/Source/VLBeaconLib/DBManager/BeaconQueryManager.swift
+++ b/Source/VLBeaconLib/DBManager/BeaconQueryManager.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-internal class BeaconQueryManager {
-    
+internal final class BeaconQueryManager {
     static let sharedInstance : BeaconQueryManager = {
         let instance = BeaconQueryManager()
         return instance
@@ -22,25 +21,11 @@ internal class BeaconQueryManager {
     
     private var dbManagerObj: BeaconDBManager
     private var beaconDBConstants: BeaconDBConstants
-    
-    private func createDBForBeaconEvents() {
-        
-        dbManagerObj.intializeData(dbFilename: beaconDBConstants.DBNAME, tableName: beaconDBConstants.USERTABLENAME, tableColumnsQuery: beaconDBConstants.USER_TABLE_COLUMNS_QUERY )
-        
-        dbManagerObj.intializeData(dbFilename: beaconDBConstants.DBNAME, tableName: beaconDBConstants.PLAYERTABLENAME, tableColumnsQuery: beaconDBConstants.PLAYER_TABLE_COLUMNS_QUERY )
-    }
-    
-    private func removeEmptyAndNilValues(from dictionary: inout [String: Any]) {
-        dictionary = dictionary.filter { key, value in
-            if let value = value as? String {
-                return !value.isEmpty
-            }
-            return true
-        }
-    }
-    
+}
+
+// MARK: - Internal methods
+extension BeaconQueryManager {
     func fetchTheUnsyncronisedBeaconEvents(_ beaconType: BeaconType) -> Array<Dictionary<String,Any>>? {
-        
         let queryToLoadAllData: String?
         
         switch beaconType{
@@ -51,13 +36,13 @@ internal class BeaconQueryManager {
             queryToLoadAllData = "select * from \(beaconDBConstants.PLAYERTABLENAME)"
         }
         
-        guard let queryToLoadAllData else{ return nil }
+        guard let queryToLoadAllData else { return nil }
         
         let customBeaconData = dbManagerObj.loadData(fromDB: queryToLoadAllData)
         
         let transformedData = customBeaconData.map { dictionaryData -> [String: Any] in
             var dataMap = dictionaryData as [String: Any]
-
+            
             if let customData = dictionaryData[additionalData]?.data(using: .utf8),
                let decodedDict = try? JSONDecoder().decode(AnyDecodable.self, from: customData).value as? [String: Any] {
                 dataMap[additionalData] = decodedDict
@@ -74,24 +59,20 @@ internal class BeaconQueryManager {
             return dataMap
         }
         
-//        print("in fetchTheUnsyncronisedBeaconEvents: \(transformedData)")
         return transformedData
     }
     
     func addBeaconEventInDB(_ beaconEvent: BeaconEventBodyProtocol) {
-        
         guard let queryToAddBeaconEvent = beaconEvent.addBeaconInDBQuery() else { return }
-//        print("in addBeaconEventInDB: \(queryToAddBeaconEvent)")
         dbManagerObj.execute(queryToAddBeaconEvent)
     }
     
-    //MARK:- Generate Query to remove data from sqlite
     func removeBeaconEventFromTheBeaconDB(_ beaconType: BeaconType) {
-        
         Log.shared.d("DB: Deleting \(beaconType) Table")
+        
         let queryToRemoveBeaconEvent: String?
         
-        switch beaconType{
+        switch beaconType {
         case .user:
             queryToRemoveBeaconEvent = "delete from \(beaconDBConstants.USERTABLENAME)"
         case .player:
@@ -102,5 +83,31 @@ internal class BeaconQueryManager {
         
         dbManagerObj.execute(queryToRemoveBeaconEvent)
     }
+}
 
+// MARK: - Private methods
+private extension BeaconQueryManager {
+    func createDBForBeaconEvents() {
+        dbManagerObj
+            .intializeData(
+                dbFilename: beaconDBConstants.DBNAME,
+                tableName: beaconDBConstants.USERTABLENAME,
+                tableColumnsQuery: beaconDBConstants.USER_TABLE_COLUMNS_QUERY
+            )
+        dbManagerObj
+            .intializeData(
+                dbFilename: beaconDBConstants.DBNAME,
+                tableName: beaconDBConstants.PLAYERTABLENAME,
+                tableColumnsQuery: beaconDBConstants.PLAYER_TABLE_COLUMNS_QUERY
+            )
+    }
+    
+    func removeEmptyAndNilValues(from dictionary: inout [String: Any]) {
+        dictionary = dictionary.filter { key, value in
+            if let value = value as? String {
+                return !value.isEmpty
+            }
+            return true
+        }
+    }
 }

--- a/Source/VLBeaconLib/DBManager/BeaconSyncManager.swift
+++ b/Source/VLBeaconLib/DBManager/BeaconSyncManager.swift
@@ -7,9 +7,8 @@
 
 import Foundation
 
-internal class BeaconSyncManager {
-    
-    static let sharedInstance : BeaconSyncManager = {
+internal final class BeaconSyncManager {
+    static let sharedInstance: BeaconSyncManager = {
         let instance = BeaconSyncManager()
         return instance
     }()
@@ -19,26 +18,28 @@ internal class BeaconSyncManager {
     }
     
     var queryManager: BeaconQueryManager
-    
-    //MARK:-  Sync Events With Server
+}
+
+// MARK: - Internal methods
+extension BeaconSyncManager {
     func startSyncingTheEvents(vlBeacon: VLBeacon, authenticationToken: String, withSuccess success: @escaping (_: Bool) -> Void) {
-        
         for beaconType in BeaconType.allCases {
             if let arrayOfBeaconEvents = queryManager.fetchTheUnsyncronisedBeaconEvents(beaconType), !arrayOfBeaconEvents.isEmpty {
                 Log.shared.d("DB: Syncing DB \(beaconType) Events")
-                self.postDataToServer(vlBeacon: vlBeacon, arrayOfBeaconEvents: arrayOfBeaconEvents, authenticationToken: authenticationToken, beaconType: beaconType)
+                
+                self.postDataToServer(
+                    vlBeacon: vlBeacon,
+                    arrayOfBeaconEvents: arrayOfBeaconEvents,
+                    authenticationToken: authenticationToken,
+                    beaconType: beaconType
+                )
             } else {
                 Log.shared.d("DB: No DB \(beaconType) Events")
             }
         }
     }
     
-    //MARK:-POST data to server
-    /// Method to post data to server in form on Array with nested dictionaries
-    ///
-    /// - Parameter arrayOfBeaconEvents: return Array
-    func postDataToServer(vlBeacon: VLBeacon, arrayOfBeaconEvents : Array<Dictionary<String,Any>>, authenticationToken: String, beaconType: BeaconType)
-    {
+    func postDataToServer(vlBeacon: VLBeacon, arrayOfBeaconEvents : Array<Dictionary<String,Any>>, authenticationToken: String, beaconType: BeaconType) {
         Log.shared.d("DB: Posting DB \(beaconType) Events")
         
         var beaconEndpoint: String = ""
@@ -54,10 +55,13 @@ internal class BeaconSyncManager {
             return
         }
         
-        DataManger().net_postOfflineBeaconEvents(beaconEventArray: arrayOfBeaconEvents, authenticationToken: authenticationToken, baseUrl: beaconEndpoint) { (response) in
-            if(response) {
-                self.queryManager.removeBeaconEventFromTheBeaconDB(beaconType)
-            }
+        DataManger().net_postOfflineBeaconEvents(beaconEventArray: arrayOfBeaconEvents,
+                                                 authenticationToken: authenticationToken,
+                                                 baseUrl: beaconEndpoint) { [weak self] (response) in
+            guard let self else { return }
+            guard response else { return }
+            
+            self.queryManager.removeBeaconEventFromTheBeaconDB(beaconType)
         }
     }
 }

--- a/Source/VLBeaconLib/VLBeacon.swift
+++ b/Source/VLBeaconLib/VLBeacon.swift
@@ -3,7 +3,6 @@
 
 import Foundation
 
-
 final public class VLBeacon {
     private static let sharedInstance = VLBeacon()
     
@@ -17,7 +16,11 @@ final public class VLBeacon {
     
     private let bundleIdentifier = "com.viewlift.beacon"
     
-    public var tokenIdentity: TokenIdentity?
+    private var _tokenIdentity: TokenIdentity?
+    public var tokenIdentity: TokenIdentity? {
+        get { tokenQueue.sync { _tokenIdentity } }
+        set { tokenQueue.sync { _tokenIdentity = newValue } }
+    }
     
     internal var userBeaconUrl : String?
     internal var playerBeaconUrl : String?
@@ -29,9 +32,9 @@ final public class VLBeacon {
     private var isOfflineEventsSynced = false
     
     private let tokenQueue = DispatchQueue(label: "com.viewlift.beacon.tokenQueue")
-
+    
     private var _authorizationToken: String?
-
+    
     public var authorizationToken: String? {
         get {
             var result: String?
@@ -41,63 +44,59 @@ final public class VLBeacon {
             return result
         }
         set {
-            tokenQueue.async {
+            tokenQueue.sync {
                 self._authorizationToken = newValue
                 guard let authorizationToken = newValue else { return }
-                self.tokenIdentity = JWTTokenParser().jwtTokenParser(jwtToken: authorizationToken)
+                self._tokenIdentity = JWTTokenParser().jwtTokenParser(jwtToken: authorizationToken)
             }
         }
     }
-
     
     public var debugLogs: Bool? = false {
-        didSet{
+        didSet {
             guard let debugLogs else { return }
+            
             Log.shared.isLoggingEnabled = debugLogs
-            if debugLogs{
+            
+            if debugLogs {
                 Log.shared.d("VLBeacon debug logs enabled!")
                 Log.shared.d("User Beacon events pointing to \(String(describing: userBeaconUrl))")
                 Log.shared.d("Player Beacon events pointing to \(String(describing: playerBeaconUrl))")
             }
-            
         }
     }
-    
-    
-    public func startSyncBeaconEvents(userBeaconUrl: String?, playerBeaconUrl: String?) {
-        
+}
+
+// MARK: - Public methods
+public extension VLBeacon {
+    func startSyncBeaconEvents(userBeaconUrl: String?, playerBeaconUrl: String?) {
         self.setupConfiguration(userBeaconUrl: userBeaconUrl, playerBeaconUrl: playerBeaconUrl)
         
         let sharedSyncManager = BeaconSyncManager.sharedInstance
         
-        if NetworkStatus.sharedInstance.isNetworkAvailable() {
-            if let authToken = authorizationToken {
-                    sharedSyncManager.startSyncingTheEvents(vlBeacon: self, authenticationToken: authToken, withSuccess: {(_ success: Bool) -> Void in
-                    })
-            }
-            
-            
-        }
-    }
-    
-    public func updatePlayerBeaconEndpoint(_ playerEndpoint: String) {
-        if playerBeaconUrl == nil, (playerBeaconUrl?.isEmpty ?? true),
-           !playerEndpoint.isEmpty {
-            playerBeaconUrl = playerEndpoint
-            environment = getEnvironment()
-        }
-    }
-    
-    public func updateUserBeaconEndpoint(_ userEndpoint: String) {
-        if userBeaconUrl == nil, (userBeaconUrl?.isEmpty ?? true),
-           !userEndpoint.isEmpty {
-            userBeaconUrl = userEndpoint
-            environment = getEnvironment()
-        }
-    }
-    
-    public func triggerBeaconEvent(_ eventStructBody: BeaconEventBodyProtocol, userMergedForAnonymousId: String? = nil) {
+        guard NetworkStatus.sharedInstance.isNetworkAvailable() else { return }
+        guard let authToken = authorizationToken else { return }
         
+        sharedSyncManager.startSyncingTheEvents(vlBeacon: self,
+                                                authenticationToken: authToken,
+                                                withSuccess: {(_ success: Bool) -> Void in })
+    }
+    
+    func updatePlayerBeaconEndpoint(_ playerEndpoint: String) {
+        guard playerBeaconUrl == nil, (playerBeaconUrl?.isEmpty ?? true), !playerEndpoint.isEmpty else { return }
+        
+        playerBeaconUrl = playerEndpoint
+        environment = getEnvironment()
+    }
+    
+    func updateUserBeaconEndpoint(_ userEndpoint: String) {
+        guard userBeaconUrl == nil, (userBeaconUrl?.isEmpty ?? true), !userEndpoint.isEmpty else { return }
+        
+        userBeaconUrl = userEndpoint
+        environment = getEnvironment()
+    }
+    
+    func triggerBeaconEvent(_ eventStructBody: BeaconEventBodyProtocol, userMergedForAnonymousId: String? = nil) {
         let deviceid = eventStructBody.toDictionary()["deviceid"] as? String
         
         if !isOfflineEventsSynced {
@@ -128,7 +127,7 @@ final public class VLBeacon {
             }
             event.mvpdprovider = mvpdProvider
             event.eventType = "Player Beacon"
-       
+            
             debugPrint("Event Player: ", event.toDictionary())
             
             if !isNetworkAvailable {
@@ -137,6 +136,9 @@ final public class VLBeacon {
             
             if let authToken = self.authorizationToken {
                 event.triggerEvents(authToken: authToken, beaconInstance: self)
+            } else {
+                // Token not ready yet — save locally, will sync when token arrives
+                BeaconOfflineHandle.saveDataToLocal(newDict: event.toDictionary())
             }
             
         } else if var eventUser = eventStructBody as? UserBeaconEventStruct {
@@ -161,29 +163,30 @@ final public class VLBeacon {
             
             if let authToken = self.authorizationToken {
                 eventUser.triggerEvents(authToken: authToken, beaconInstance: self)
+            } else {
+                // Token not ready yet — save locally, will sync when token arrives
+                BeaconOfflineHandle.saveDataToLocal(newDict: eventUser.toDictionary())
             }
         }
     }
-    
 }
-extension VLBeacon{
-    
-    
-    private func getDebugLogger() -> Bool? {
+
+// MARK: - Private methods
+private extension VLBeacon {
+    func getDebugLogger() -> Bool? {
         guard let bundlePath = Bundle.main.path(forResource: "SiteConfig", ofType: "plist"),
               let dict = NSDictionary.init(contentsOfFile: bundlePath),
               let loggerValue = dict["VLBeaconDebugLogger"] as? Bool else {return false}
         return loggerValue
     }
     
-    private func setupConfiguration(userBeaconUrl: String?, playerBeaconUrl: String?) {
+    func setupConfiguration(userBeaconUrl: String?, playerBeaconUrl: String?) {
         self.userBeaconUrl = userBeaconUrl
         self.playerBeaconUrl = playerBeaconUrl
         
         environment = getEnvironment()
         debugLogs = getDebugLogger()
     }
-    
     
     func getEnvironment() -> String {
         guard let bundlePath = Bundle.main.path(forResource: "SiteConfig", ofType: "plist"),
@@ -205,5 +208,4 @@ extension VLBeacon{
             return "production"
         }
     }
-    
 }


### PR DESCRIPTION
https://viewlift.freshdesk.com/a/tickets/314079
Fixed race condition in authorizationToken causing missing PLAY beacon

- Minor refactoring
- Clean code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core beacon dispatch and auth token threading; wrong timing could duplicate events (offline + immediate send) or delay sync until token/network paths run.
> 
> **Overview**
> Fixes a race where **PLAY** (and other) beacons could be dropped when `authorizationToken` was not ready yet, by making token/identity updates **synchronous** on `tokenQueue` and **persisting** user/player events locally when no token is available (same path as offline).
> 
> **`VLBeacon`**: `authorizationToken` setter now uses `tokenQueue.sync` (was async) so JWT parsing and `_tokenIdentity` update complete before callers continue; `tokenIdentity` reads/writes are also queue-synchronized. **`triggerBeaconEvent`** adds an `else` branch to call `BeaconOfflineHandle.saveDataToLocal` when `authorizationToken` is nil.
> 
> **Offline / sync**: Corrects a broken error log in `BeaconOfflineHandle` (`\(error)`). **`BeaconSyncManager`** uses `[weak self]` in the post callback.
> 
> Remaining diff is **structure-only** across DB/beacon types: `final` classes, MARK extensions, guard-style refactors, and minor formatting—no intended behavior change beyond the token race and early-event persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ea60ada2d46c6b5becd0daf27b1dc34885c6e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->